### PR TITLE
feat(ci): Publish distro to Dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.7
+          # version: 20.10.7
           privileged: true  # Required for Buildx
       # - run:
       #     name: Install QEMU for Multi-Arch Builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ executors:
 jobs:
   build-and-push-multiarch:
     executor: docker-executor
+    resource_class: xlarge
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --push \
-              -t $DOCKER_USERNAME/opentelemetry-collector-symbolicator:$CIRCLE_SHA1 \
-              -t $DOCKER_USERNAME/opentelemetry-collector-symbolicator:latest \
+              -t honeycombio/opentelemetry-collector-symbolicator:$CIRCLE_SHA1 \
+              -t honeycombio/opentelemetry-collector-symbolicator:latest \
               .
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --push \
-              -t $DOCKER_USERNAME/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
-              -t $DOCKER_USERNAME/honeycomb-opentelemetry-collector:latest \
+              -t $DOCKER_USERNAME/opentelemetry-collector-symbolicator:$CIRCLE_SHA1 \
+              -t $DOCKER_USERNAME/opentelemetry-collector-symbolicator:latest \
               .
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,15 +28,15 @@ jobs:
             # make build-docker
       - run:
           name: Login to Docker Hub
-          command: echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+          command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       - run:
           name: Build and Push Multi-Arch Docker Image
           command: |
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --push \
-              -t $DOCKERHUB_USERNAME/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
-              -t $DOCKERHUB_USERNAME/honeycomb-opentelemetry-collector:latest \
+              -t $DOCKER_USERNAME/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              -t $DOCKER_USERNAME/honeycomb-opentelemetry-collector:latest \
               .
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,8 @@ jobs:
             docker buildx build \
               --platform linux/amd64,linux/arm64 \
               --push \
-              -t honeycombio/opentelemetry-collector-symbolicator:$CIRCLE_SHA1 \
-              -t honeycombio/opentelemetry-collector-symbolicator:latest \
+              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              -t honeycombio/honeycomb-opentelemetry-collector:latest \
               .
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
           command: |
             docker run --rm --privileged tonistiigi/binfmt --install all
       - run:
+          no_output_timeout: 30m
           name: Set up Docker Buildx
           command: |
             docker buildx create --use --name multiarch_builder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,43 @@
+version: 2.1
+
+executors:
+  docker-executor:
+    docker:
+      - image: cimg/base:stable
+        user: root
+
+jobs:
+  build-and-push-multiarch:
+    executor: docker-executor
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.7
+          privileged: true  # Required for Buildx
+      # - run:
+      #     name: Install QEMU for Multi-Arch Builds
+      #     command: |
+      #       docker run --rm --privileged tonistiigi/binfmt --install all
+      - run:
+          name: Set up Docker Buildx
+          command: |
+            docker buildx create --use --name multiarch_builder
+            docker buildx inspect --bootstrap  # Ensures everything is set up correctly
+            make build-docker
+      # - run:
+      #     name: Login to Docker Hub
+      #     command: echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+      # - run:
+      #     name: Build and Push Multi-Arch Docker Image
+      #     command: |
+      #       docker buildx build \
+      #         --platform linux/amd64,linux/arm64 \
+      #         --push \
+      #         -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$CIRCLE_SHA1 \
+      #         -t $DOCKERHUB_USERNAME/$IMAGE_NAME:latest \
+              # .
+workflows:
+  version: 2
+  build-and-push-workflow:
+    jobs:
+      - build-and-push-multiarch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,10 +15,10 @@ jobs:
       - setup_remote_docker:
           # version: 20.10.7
           privileged: true  # Required for Buildx
-      # - run:
-      #     name: Install QEMU for Multi-Arch Builds
-      #     command: |
-      #       docker run --rm --privileged tonistiigi/binfmt --install all
+      - run:
+          name: Install QEMU for Multi-Arch Builds
+          command: |
+            docker run --rm --privileged tonistiigi/binfmt --install all
       - run:
           name: Set up Docker Buildx
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,21 +25,22 @@ jobs:
           command: |
             docker buildx create --use --name multiarch_builder
             docker buildx inspect --bootstrap  # Ensures everything is set up correctly
-            make build-docker
-      # - run:
-      #     name: Login to Docker Hub
-      #     command: echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
-      # - run:
-      #     name: Build and Push Multi-Arch Docker Image
-      #     command: |
-      #       docker buildx build \
-      #         --platform linux/amd64,linux/arm64 \
-      #         --push \
-      #         -t $DOCKERHUB_USERNAME/$IMAGE_NAME:$CIRCLE_SHA1 \
-      #         -t $DOCKERHUB_USERNAME/$IMAGE_NAME:latest \
-              # .
+            # make build-docker
+      - run:
+          name: Login to Docker Hub
+          command: echo $DOCKERHUB_PASSWORD | docker login -u $DOCKERHUB_USERNAME --password-stdin
+      - run:
+          name: Build and Push Multi-Arch Docker Image
+          command: |
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --push \
+              -t $DOCKERHUB_USERNAME/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              -t $DOCKERHUB_USERNAME/honeycomb-opentelemetry-collector:latest \
+              .
 workflows:
   version: 2
   build-and-push-workflow:
     jobs:
-      - build-and-push-multiarch
+      - build-and-push-multiarch:
+          context: Honeycomb Secrets for Public Repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          # version: 20.10.7
           privileged: true  # Required for Buildx
       - run:
           name: Install QEMU for Multi-Arch Builds
@@ -36,6 +35,7 @@ jobs:
               --platform linux/amd64,linux/arm64 \
               --push \
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_TAG \
               -t honeycombio/honeycomb-opentelemetry-collector:latest \
               .
 workflows:
@@ -44,3 +44,8 @@ workflows:
     jobs:
       - build-and-push-multiarch:
           context: Honeycomb Secrets for Public Repos
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: builder
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build . -t honeycomb-otelcol
+	docker buildx build --platform linux/arm64 . -t honeycomb-otelcol
 
 .PHONY: run
 run: build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: builder
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build --platform linux/arm64 . -t honeycomb-otelcol
+	docker buildx build --platform linux/arm64 --progress=plain . -t honeycomb-otelcol
 
 .PHONY: run
 run: build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ build: builder
 
 .PHONY: build-docker
 build-docker:
-	docker buildx build --platform linux/arm64 --progress=plain . -t honeycomb-otelcol
+	docker buildx build --platform linux/amd64,linux/arm64 --progress=plain . -t honeycomb-otelcol
 
 .PHONY: run
 run: build


### PR DESCRIPTION
## Which problem is this PR solving?
This PR makes the distro available through a public dockerhub repo.

## Short description of the changes
- Added CircleCI config to build and publish image to dockerhub
- Should only build and publish for tags

## How to verify that this has the expected result
- See the [image available in dockerhub](https://hub.docker.com/repository/docker/honeycombio/honeycomb-opentelemetry-collector/general)
- [Succuessful CircleCI Job](https://app.circleci.com/pipelines/github/honeycombio/honeycomb-collector-distro/14/workflows/d59ccb5b-14a0-40df-b27b-d51919766a84)
