### PR TITLE
feat: Use nonroot user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN make build
 
 FROM gcr.io/distroless/cc
 
+USER nonroot
+
 COPY --from=build --chmod=755 /go/src/bin/honeycomb-otelcol /honeycomb-otelcol
 COPY --from=build  /go/src/config.yaml /
 COPY --from=build /go/pkg/mod/github.com/honeycombio/ /go/pkg/mod/github.com/honeycombio/


### PR DESCRIPTION
The distroless images come with a nonroot user configured so lets use that instead of the root user