### PR TITLE
fix: Use current image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   docker-executor:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current
         user: root
 
 jobs:


### PR DESCRIPTION
The `stable` tag is over two years old and doesn't support the attestation features that we are now using.

This is what the docs say about the `current` tag which seems like what we want

> current - This image tag points to the most recent monthly snapshot. This image should be used by projects that want a decent level of stability but would like to get occasional software updates. It is typically updated once a month. While not often, this tag can introduce breaking changes.

https://hub.docker.com/r/cimg/base