### PR TITLE
rel: v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
-## v0.0.2 [beta] - 2025/02/20
+## v0.0.3 [beta] - 2025/02/21
 
 ### 🛠️ Maintenance
 


### PR DESCRIPTION
`v0.0.2` did not work due to an old image being used, re-releasing as `v0.0.3`