### PR TITLE
ci: Update description when pushing to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ jobs:
               --provenance=true \
               --push \
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_TAG \
+              -t honeycombio/honeycomb-opentelemetry-collector:latest \
+
               .
       - docker/update-description:
           docker-username: DOCKER_USERNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,23 +23,22 @@ jobs:
           command: |
             docker buildx create --use --name multiarch_builder
             docker buildx inspect --bootstrap  # Ensures everything is set up correctly
-            # make build-docker
       - run:
           name: Login to Docker Hub
           command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-      - run:
-          name: Build and Push Multi-Arch Docker Image
-          command: |
-            docker buildx build \
-              --platform linux/amd64,linux/arm64 \
-              --sbom=true \
-              --provenance=true \
-              --push \
-              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
-              .
+      # - run:
+      #     name: Build and Push Multi-Arch Docker Image
+      #     command: |
+      #       docker buildx build \
+      #         --platform linux/amd64,linux/arm64 \
+      #         --sbom=true \
+      #         --provenance=true \
+      #         --push \
+      #         -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+      #         .
       - docker/update-description:
           docker-username: DOCKER_USERNAME
-          docker-password: DOCKER_PASSWORD
+          docker-password: DOCKER_TOKEN
           image: honeycombio/honeycomb-opentelemetry-collector
           # readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ jobs:
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
               .
       - docker/update-description:
-          docker-username: $DOCKER_USERNAME
-          docker-password: $DOCKER_PASSWORD
+          docker-username: DOCKER_USERNAME
+          docker-password: DOCKER_PASSWORD
           image: honeycombio/honeycomb-opentelemetry-collector
           # readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
       - docker/update-description:
           username: $DOCKER_USERNAME
           password: $DOCKER_PASSWORD
-          repository: honeycombio/honeycomb-opentelemetry-collector
+          image: honeycombio/honeycomb-opentelemetry-collector
           readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             docker buildx inspect --bootstrap  # Ensures everything is set up correctly
       - run:
           name: Login to Docker Hub
-          command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
+          command: echo $DOCKER_TOKEN | docker login -u $DOCKER_USERNAME --password-stdin
       # - run:
       #     name: Build and Push Multi-Arch Docker Image
       #     command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
             docker buildx inspect --bootstrap  # Ensures everything is set up correctly
       - run:
           name: Login to Docker Hub
-          command: echo $DOCKER_TOKEN | docker login -u $DOCKER_USERNAME --password-stdin
+          command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
       # - run:
       #     name: Build and Push Multi-Arch Docker Image
       #     command: |
@@ -38,7 +38,7 @@ jobs:
       #         .
       - docker/update-description:
           docker-username: DOCKER_USERNAME
-          docker-password: DOCKER_TOKEN
+          docker-password: DOCKER_PASSWORD
           image: honeycombio/honeycomb-opentelemetry-collector
           # readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,6 @@ jobs:
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_TAG \
               -t honeycombio/honeycomb-opentelemetry-collector:latest \
-
               .
       - docker/update-description:
           docker-username: DOCKER_USERNAME

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,10 +38,10 @@ jobs:
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
               .
       - docker/update-description:
-          username: $DOCKER_USERNAME
-          password: $DOCKER_PASSWORD
+          docker-username: $DOCKER_USERNAME
+          docker-password: $DOCKER_PASSWORD
           image: honeycombio/honeycomb-opentelemetry-collector
-          readme-path: README.md  # Syncs README.md with Docker Hub description
+          # readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:
   version: 2
   build-and-push-workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  docker: circleci/docker@2.8.2
+
 executors:
   docker-executor:
     docker:
@@ -33,17 +36,20 @@ jobs:
               --provenance=true \
               --push \
               -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
-              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_TAG \
-              -t honeycombio/honeycomb-opentelemetry-collector:latest \
               .
+      - docker/update-description:
+          username: $DOCKER_USERNAME
+          password: $DOCKER_PASSWORD
+          repository: honeycombio/honeycomb-opentelemetry-collector
+          readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:
   version: 2
   build-and-push-workflow:
     jobs:
       - build-and-push-multiarch:
           context: Honeycomb Secrets for Public Repos
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,29 +26,28 @@ jobs:
       - run:
           name: Login to Docker Hub
           command: echo $DOCKER_PASSWORD | docker login -u $DOCKER_USERNAME --password-stdin
-      # - run:
-      #     name: Build and Push Multi-Arch Docker Image
-      #     command: |
-      #       docker buildx build \
-      #         --platform linux/amd64,linux/arm64 \
-      #         --sbom=true \
-      #         --provenance=true \
-      #         --push \
-      #         -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
-      #         .
+      - run:
+          name: Build and Push Multi-Arch Docker Image
+          command: |
+            docker buildx build \
+              --platform linux/amd64,linux/arm64 \
+              --sbom=true \
+              --provenance=true \
+              --push \
+              -t honeycombio/honeycomb-opentelemetry-collector:$CIRCLE_SHA1 \
+              .
       - docker/update-description:
           docker-username: DOCKER_USERNAME
           docker-password: DOCKER_PASSWORD
           image: honeycombio/honeycomb-opentelemetry-collector
-          # readme-path: README.md  # Syncs README.md with Docker Hub description
 workflows:
   version: 2
   build-and-push-workflow:
     jobs:
       - build-and-push-multiarch:
           context: Honeycomb Secrets for Public Repos
-          # filters:
-          #   tags:
-          #     only: /^v.*/
-          #   branches:
-          #     ignore: /.*/
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 Honeycomb's OpenTelemetry collector distribution built with [OCB](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder).
 
-<!-- OSS metadata badge - rename repo link and set status in OSSMETADATA -->
-<!-- [![OSS Lifecycle](https://img.shields.io/osslifecycle/honeycombio/{repo-name})](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md) -->
+## Run the collector
+
+```sh
+docker pull honeycombio/honeycomb-opentelemetry-collector:latest
+```
+
+```sh
+docker run \
+  -p 14268:14268 \
+  -p 4317-4318:4317-4318 \
+  honeycombio/honeycomb-opentelemetry-collector:latest
+```
 
 ## Components
 


### PR DESCRIPTION
## Which problem is this PR solving?
Addresses the "Overview" section of dockerhub being empty.

## Short description of the changes
- Push README to image description on push to docker hub

## How to verify that this has the expected result
[Take a look at the "Overview" section in docker hub.](https://hub.docker.com/repository/docker/honeycombio/honeycomb-opentelemetry-collector/general)