### PR TITLE
feat: Adds resource detection processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ docker run \
 | Processor      | attributesprocessor | [attributesprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor) |
 | Processor      | transformprocessor | [transformprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor) |
 | Processor      | symbolicatorprocessor | [symbolicatorprocessor](https://pkg.go.dev/github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorprocessor) |
+| Processor      | resourcedetectionprocessor | [resourcedetectionprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor) |
 | Receiver       | otlpreceiver   | [otlpreceiver](https://pkg.go.dev/go.opentelemetry.io/collector/receiver/otlpreceiver) |
 | Receiver       | nopreceiver    | [nopreceiver](https://pkg.go.dev/go.opentelemetry.io/collector/receiver/nopreceiver) |
 | Receiver       | filelogreceiver | [filelogreceiver](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver) |

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -18,6 +18,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.121.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.121.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorprocessor v0.0.6
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.121.0
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.121.0


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Short description of the changes

The resource detection processor is pretty popular. This adds it to the manifest for the honeycomb collector build. 

## How to verify that this has the expected result

Build it with this configuration and use the following config snippet for processors:

```yaml
processors:
  batch:
  memory_limiter:
    check_interval: 1s
    limit_mib: 20000
    spike_limit_mib: 2000
  resourcedetection/heroku:
    detectors: [env, heroku]
    timeout: 5s
    override: false
```