### PR TITLE
feat: Add headerssetterextension

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,6 @@ docker run \
 | Provider       | s3provider | [s3provider](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider) |
 | Extension      | zpagesextension | [zpagesextension](https://pkg.go.dev/go.opentelemetry.io/collector/extension/zpagesextension) |
 | Extension      | bearertokenauthextension | [bearertokenauthextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension) |
+| Extension      | headerssetterextension | [headerssetterextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension) |
 | Extension      | healthcheckextension | [healthcheckextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension) |
 | Extension      | pprofextension | [pprofextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension) |

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -45,5 +45,6 @@ providers:
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.123.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.123.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.123.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.123.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.123.0


### PR DESCRIPTION
## Short description of the changes

Adds the `headerssetterextension` that allows headers to be persisted through the pipeline. This will be useful when receiving honeycomb telemetry where you want the client to control the destination dataset etc.