### PR TITLE
rel: prep for v0.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
+## v0.0.10 [beta] - 2025/08/16
+### ✨ Features
+
+- feat: add dSYM processor (#37) | @mustafahaddara
+
+### 🛠️ Maintenance
+
+- maint: Update collector and collector contrib dependencies to latest version (#35) | @martin308
+
 ## v0.0.9 [beta] - 2025/04/29
 
 ### ✨ Features


### PR DESCRIPTION
looks like @martin308 updating`builder-config.yaml` to version 0.0.10 in #35 but we never released that.