### PR TITLE
maint: update dsymprocessor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
+## v0.0.11 [beta] - 2025/08/25
+### 🛠️ Maintenance
+
+- maint: update dsymprocessor version (#39) | @mustafahaddara
+
 ## v0.0.10 [beta] - 2025/08/16
 ### ✨ Features
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.10
+  version: 0.0.11
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.128.0


### PR DESCRIPTION
## Which problem is this PR solving?
Updates dsymprocessor to latest version, which includes the ability to symbolicate generic stack traces: https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/73

Also includes the necessary changes to prep for a new release of this distro.