### PR TITLE
feat: update symbolicator and dsymprocessor versions so error messages are included

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
+## v0.0.13 [beta] - 2025/06/27
+### ✨ Features
+
+- feat: update symbolicator and dsymprocessor versions so error messages are included (#41) | @mustafahaddara
+
 ## v0.0.12 [beta] - 2025/06/26
 ### 🛠️ Maintenance
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -19,8 +19,8 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.128.0
-  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorprocessor v0.0.7
-  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor 054221ce49fab41db89e60d6896b89c8d122e6ec
+  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorprocessor v0.0.8
+  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v0.0.4
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.128.0

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -20,7 +20,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.128.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.128.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/symbolicatorprocessor v0.0.7
-  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v0.0.3
+  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor 054221ce49fab41db89e60d6896b89c8d122e6ec
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.128.0

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.12
+  version: 0.0.13
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.128.0


### PR DESCRIPTION
Brings in the latest versions of `symbolicatorprocessor` and `dsymprocessor` from https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/77

And includes prep for release 0.0.13 so this can be released after merge.