### PR TITLE
rel: v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
+## v0.0.14 [beta] - 2025/07/02
+### ✨ Features
+- maint: update symbolicatorprocessor/v0.0.9 dsymprocessor/v0.0.5 proguardprocessor/v0.0.2 (#43)
+### ✨ Maintenance
+- maint: collector v0.129.0/v1.35.0 (#42)
+
 ## v0.0.13 [beta] - 2025/06/27
 ### ✨ Features
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.13
+  version: 0.0.14
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0


### PR DESCRIPTION
Updated builder-config.yaml to set the distribution version to 0.0.14. Added changelog entries for new processor versions and collector maintenance updates.
