### PR TITLE
maint: update proguardprocessor to v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Honeycomb OpenTelemetry Collector Distro changelog
 
+## Unreleased
+- maint: update proguardprocessor to v0.0.4
+
 ## v0.0.15 [beta] - 2025/07/24
 ### 🚨 Breaking Changes
 - maint: update sourcemapprocessor/v0.0.10 dsymprocessor/v0.0.6 proguardprocessor/v0.0.3 (#45) | @mustafahaddara

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -21,7 +21,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.129.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v0.0.10
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v0.0.6
-  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v0.0.3
+  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v0.0.4
 
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0


### PR DESCRIPTION
Bumping proguardprocessor to the latest release.
