### PR TITLE
feat(receivers): add awsfirehose

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -26,6 +26,7 @@ processors:
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.129.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.129.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.129.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.129.0


### PR DESCRIPTION
## Which problem is this PR solving?

- We cannot use the collector distro to mux kinesis streams.

## Short description of the changes

This allows us to act as a fan-out service for receiving OTLP kinesis streams and processing them through the metrics batching and fanning them out to multiple exporters.

## How to verify that this has the expected result

Builds successfully, configs with the receiver work