### PR TITLE
rel: prep for v0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.0.18 [beta] - 2025/09/03
+
+### ✨ Features
+
+- feat(receivers): add awsfirehose receiver and metricstransformprocessor to enable Kinesis stream processing (#52) | @lizthegrey
+- feat: add public ECR registry distribution for improved availability (#51) | @lizthegrey
+
+### 🛠️ Maintenance
+
+- maint: update collector v0.134.0/v1.40.0 (#54) | @lizthegrey
+
 ## v0.0.17 [beta] - 2025/08/21
 
 - chore: Add a `tmp` volume to the docker file so that we can cache the proguard mapper since it expects to be passed a cached file.

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.17
+  version: 0.0.18
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.134.0


### PR DESCRIPTION
## Summary
- Update CHANGELOG.md with v0.0.18 changes
- Update builder-config.yaml version to 0.0.18

## Changes included in this release
- feat(receivers): add awsfirehose receiver and metricstransformprocessor to enable Kinesis stream processing (#52)
- feat: add public ECR registry distribution for improved availability (#51)

🤖 Generated with [Claude Code](https://claude.ai/code)