### PR TITLE
maint: update collector v0.134.0/v1.40.0

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -6,51 +6,51 @@ dist:
   version: 0.0.17
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.129.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.129.0
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.129.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.129.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.134.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.134.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.134.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.134.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.129.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.129.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.134.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.134.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v0.0.10
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v0.0.6
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v0.0.4
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.129.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.129.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.134.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sobjectsreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/libhoneyreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.134.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.35.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.35.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.35.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.35.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.35.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.129.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.40.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.40.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.40.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.40.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.40.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.134.0
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.129.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.129.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.134.0


### PR DESCRIPTION
## Summary
- Update OpenTelemetry Collector and Collector Contrib to v0.134.0
- Update core collector providers to v1.40.0

## Changes
- All exporters, processors, receivers, and extensions updated to v0.134.0  
- Confmap providers updated to v1.40.0
- Maintains compatibility with existing configurations

🤖 Generated with [Claude Code](https://claude.ai/code)