### PR TITLE
ci: add automated dependency update workflow

### DIFF
--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -19,11 +19,15 @@ jobs:
       new_core_v0: ${{ steps.check.outputs.new_core_v0 }}
       new_core_v1: ${{ steps.check.outputs.new_core_v1 }}
       new_contrib_v0: ${{ steps.check.outputs.new_contrib_v0 }}
+      go_updated: ${{ steps.check.outputs.go_updated }}
+      new_go_minor: ${{ steps.check.outputs.new_go_minor }}
     steps:
       - uses: actions/checkout@v4
 
       - name: Check for OTel Collector updates
         id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get current versions from builder-config.yaml
           CURRENT_CORE_V0=$(grep -m1 'go.opentelemetry.io/collector/exporter/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
@@ -32,6 +36,10 @@ jobs:
           echo "Current collector core v0: $CURRENT_CORE_V0"
           echo "Current collector core v1: $CURRENT_CORE_V1"
           echo "Current collector contrib v0: $CURRENT_CONTRIB_V0"
+
+          # Get current Go major.minor from Dockerfile
+          CURRENT_GO_MINOR=$(grep -oP '(?<=FROM golang:)\d+\.\d+' Dockerfile)
+          echo "Current Go version in Dockerfile: $CURRENT_GO_MINOR"
 
           # Query the Go module proxy for latest stable versions
           # The /@latest endpoint returns only stable releases, skipping pre-release/beta/RC versions
@@ -43,6 +51,11 @@ jobs:
 
           LATEST_CONTRIB_V0=$(curl -sf 'https://proxy.golang.org/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/@latest' | jq -r '.Version')
           echo "Latest collector contrib v0 (from Go proxy): $LATEST_CONTRIB_V0"
+
+          # Check the Go version from the collector's go.mod (major.minor only)
+          UPSTREAM_GO=$(gh api repos/open-telemetry/opentelemetry-collector/contents/go.mod --jq '.content' \
+            | base64 -d | grep -oP '(?<=^go )\d+\.\d+' | head -1)
+          echo "Upstream collector Go version: $UPSTREAM_GO"
 
           CORE_V0_CHANGED="false"
           CORE_V1_CHANGED="false"
@@ -58,7 +71,12 @@ jobs:
             CONTRIB_V0_CHANGED="true"
           fi
 
-          if [ "$CORE_V0_CHANGED" == "true" ] || [ "$CORE_V1_CHANGED" == "true" ] || [ "$CONTRIB_V0_CHANGED" == "true" ]; then
+          GO_CHANGED="false"
+          if [ "$UPSTREAM_GO" != "$CURRENT_GO_MINOR" ]; then
+            GO_CHANGED="true"
+          fi
+
+          if [ "$CORE_V0_CHANGED" == "true" ] || [ "$CORE_V1_CHANGED" == "true" ] || [ "$CONTRIB_V0_CHANGED" == "true" ] || [ "$GO_CHANGED" == "true" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "new_core_v0=$LATEST_CORE_V0" >> "$GITHUB_OUTPUT"
             echo "new_core_v1=$LATEST_CORE_V1" >> "$GITHUB_OUTPUT"
@@ -67,9 +85,17 @@ jobs:
             echo "  Core v0: $CURRENT_CORE_V0 -> $LATEST_CORE_V0 (changed: $CORE_V0_CHANGED)"
             echo "  Core v1: $CURRENT_CORE_V1 -> $LATEST_CORE_V1 (changed: $CORE_V1_CHANGED)"
             echo "  Contrib v0: $CURRENT_CONTRIB_V0 -> $LATEST_CONTRIB_V0 (changed: $CONTRIB_V0_CHANGED)"
+            echo "  Go: $CURRENT_GO_MINOR -> $UPSTREAM_GO (changed: $GO_CHANGED)"
           else
             echo "updated=false" >> "$GITHUB_OUTPUT"
             echo "OTel Collector is up to date"
+          fi
+
+          if [ "$GO_CHANGED" == "true" ]; then
+            echo "go_updated=true" >> "$GITHUB_OUTPUT"
+            echo "new_go_minor=$UPSTREAM_GO" >> "$GITHUB_OUTPUT"
+          else
+            echo "go_updated=false" >> "$GITHUB_OUTPUT"
           fi
 
   check-honeycomb-deps:
@@ -165,6 +191,8 @@ jobs:
           NEW_CORE_V0: ${{ needs.check-otel-collector.outputs.new_core_v0 }}
           NEW_CORE_V1: ${{ needs.check-otel-collector.outputs.new_core_v1 }}
           NEW_CONTRIB_V0: ${{ needs.check-otel-collector.outputs.new_contrib_v0 }}
+          GO_UPDATED: ${{ needs.check-otel-collector.outputs.go_updated }}
+          NEW_GO_MINOR: ${{ needs.check-otel-collector.outputs.new_go_minor }}
         run: |
           # Get current versions
           CURRENT_CORE_V0=$(grep -m1 'go.opentelemetry.io/collector/exporter/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
@@ -199,13 +227,22 @@ jobs:
           # Update contrib v0.x versions (opentelemetry-collector-contrib modules)
           sed -i "/opentelemetry-collector-contrib\//s|${CURRENT_CONTRIB_V0}|${NEW_CONTRIB_V0}|g" builder-config.yaml
 
+          # Update Go version in Dockerfile if changed
+          GO_BODY_LINE=""
+          if [ "$GO_UPDATED" == "true" ]; then
+            CURRENT_GO_MINOR=$(grep -oP '(?<=FROM golang:)\d+\.\d+' Dockerfile)
+            sed -i "s|FROM golang:${CURRENT_GO_MINOR}|FROM golang:${NEW_GO_MINOR}|g" Dockerfile
+            echo "Go version: $CURRENT_GO_MINOR -> $NEW_GO_MINOR"
+            GO_BODY_LINE="- Go version (Dockerfile): \`${CURRENT_GO_MINOR}\` → \`${NEW_GO_MINOR}\`"
+          fi
+
           echo "Updated files:"
           git diff
 
           # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add builder-config.yaml Makefile
+          git add builder-config.yaml Makefile Dockerfile
           git commit -m "$TITLE"
           git push origin "$BRANCH"
 
@@ -220,6 +257,7 @@ jobs:
           - Confmap providers: \`${NEW_CORE_V1}\`
           - Collector Contrib modules: \`${NEW_CONTRIB_V0}\`
           - Builder: \`${NEW_CORE_V0}\`
+          ${GO_BODY_LINE}
 
           ## How to verify
 

--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -1,0 +1,359 @@
+name: "Check Dependency Updates"
+
+on:
+  schedule:
+    # Run daily at 14:00 UTC (morning US time zones)
+    - cron: "0 14 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-otel-collector:
+    name: Check OTel Collector Updates
+    runs-on: ubuntu-latest
+    outputs:
+      updated: ${{ steps.check.outputs.updated }}
+      new_core_v0: ${{ steps.check.outputs.new_core_v0 }}
+      new_core_v1: ${{ steps.check.outputs.new_core_v1 }}
+      new_contrib_v0: ${{ steps.check.outputs.new_contrib_v0 }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for OTel Collector updates
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Get current versions from builder-config.yaml
+          CURRENT_CORE_V0=$(grep -m1 'go.opentelemetry.io/collector/exporter/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
+          CURRENT_CORE_V1=$(grep -m1 'go.opentelemetry.io/collector/confmap/provider/' builder-config.yaml | grep -oP 'v1\.\d+\.\d+')
+          CURRENT_CONTRIB_V0=$(grep -m1 'opentelemetry-collector-contrib/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
+          echo "Current collector core v0: $CURRENT_CORE_V0"
+          echo "Current collector core v1: $CURRENT_CORE_V1"
+          echo "Current collector contrib v0: $CURRENT_CONTRIB_V0"
+
+          # Check open-telemetry/opentelemetry-collector for core v0.x tags
+          LATEST_CORE_V0=$(gh api repos/open-telemetry/opentelemetry-collector/tags --per_page=100 \
+            --jq '[.[].name | select(test("^v0\\.\\d+\\.\\d+$"))] | first')
+          echo "Latest collector core v0 tag: $LATEST_CORE_V0"
+
+          # Check open-telemetry/opentelemetry-collector for core v1.x tags (confmap providers)
+          LATEST_CORE_V1=$(gh api repos/open-telemetry/opentelemetry-collector/tags --per_page=100 \
+            --jq '[.[].name | select(test("^v1\\.\\d+\\.\\d+$"))] | first')
+          echo "Latest collector core v1 tag: $LATEST_CORE_V1"
+
+          # Check open-telemetry/opentelemetry-collector-contrib for contrib v0.x tags
+          LATEST_CONTRIB_V0=$(gh api repos/open-telemetry/opentelemetry-collector-contrib/tags --per_page=100 \
+            --jq '[.[].name | select(test("^v0\\.\\d+\\.\\d+$"))] | first')
+          echo "Latest collector contrib v0 tag: $LATEST_CONTRIB_V0"
+
+          CORE_V0_CHANGED="false"
+          CORE_V1_CHANGED="false"
+          CONTRIB_V0_CHANGED="false"
+
+          if [ "$LATEST_CORE_V0" != "$CURRENT_CORE_V0" ]; then
+            CORE_V0_CHANGED="true"
+          fi
+          if [ "$LATEST_CORE_V1" != "$CURRENT_CORE_V1" ]; then
+            CORE_V1_CHANGED="true"
+          fi
+          if [ "$LATEST_CONTRIB_V0" != "$CURRENT_CONTRIB_V0" ]; then
+            CONTRIB_V0_CHANGED="true"
+          fi
+
+          if [ "$CORE_V0_CHANGED" == "true" ] || [ "$CORE_V1_CHANGED" == "true" ] || [ "$CONTRIB_V0_CHANGED" == "true" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "new_core_v0=$LATEST_CORE_V0" >> "$GITHUB_OUTPUT"
+            echo "new_core_v1=$LATEST_CORE_V1" >> "$GITHUB_OUTPUT"
+            echo "new_contrib_v0=$LATEST_CONTRIB_V0" >> "$GITHUB_OUTPUT"
+            echo "Updates available:"
+            echo "  Core v0: $CURRENT_CORE_V0 -> $LATEST_CORE_V0 (changed: $CORE_V0_CHANGED)"
+            echo "  Core v1: $CURRENT_CORE_V1 -> $LATEST_CORE_V1 (changed: $CORE_V1_CHANGED)"
+            echo "  Contrib v0: $CURRENT_CONTRIB_V0 -> $LATEST_CONTRIB_V0 (changed: $CONTRIB_V0_CHANGED)"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+            echo "OTel Collector is up to date"
+          fi
+
+  check-honeycomb-deps:
+    name: Check Honeycomb Dependency Updates
+    runs-on: ubuntu-latest
+    outputs:
+      s3_exporter_updated: ${{ steps.s3_exporter.outputs.updated }}
+      s3_exporter_version: ${{ steps.s3_exporter.outputs.version }}
+      symbolicator_sourcemap_updated: ${{ steps.symbolicator_sourcemap.outputs.updated }}
+      symbolicator_sourcemap_version: ${{ steps.symbolicator_sourcemap.outputs.version }}
+      symbolicator_dsym_updated: ${{ steps.symbolicator_dsym.outputs.updated }}
+      symbolicator_dsym_version: ${{ steps.symbolicator_dsym.outputs.version }}
+      symbolicator_proguard_updated: ${{ steps.symbolicator_proguard.outputs.updated }}
+      symbolicator_proguard_version: ${{ steps.symbolicator_proguard.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check enhance-indexing-s3-exporter
+        id: s3_exporter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT=$(grep 'enhance-indexing-s3-exporter' builder-config.yaml | grep -oP 'v[\d.]+')
+          echo "Current s3-exporter version: $CURRENT"
+
+          LATEST=$(gh api repos/honeycombio/enhance-indexing-s3-exporter/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
+          if [ -z "$LATEST" ]; then
+            LATEST=$(gh api repos/honeycombio/enhance-indexing-s3-exporter/tags --jq '.[0].name' 2>/dev/null || echo "$CURRENT")
+          fi
+          echo "Latest s3-exporter version: $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check symbolicator/sourcemapprocessor
+        id: symbolicator_sourcemap
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT=$(grep 'symbolicator/sourcemapprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+          echo "Current sourcemapprocessor version: $CURRENT"
+
+          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("sourcemapprocessor/"))] | first' 2>/dev/null || echo "")
+          if [ -n "$LATEST" ]; then
+            LATEST=$(echo "$LATEST" | sed 's|sourcemapprocessor/||')
+          else
+            LATEST="$CURRENT"
+          fi
+          echo "Latest sourcemapprocessor version: $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check symbolicator/dsymprocessor
+        id: symbolicator_dsym
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT=$(grep 'symbolicator/dsymprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+          echo "Current dsymprocessor version: $CURRENT"
+
+          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("dsymprocessor/"))] | first' 2>/dev/null || echo "")
+          if [ -n "$LATEST" ]; then
+            LATEST=$(echo "$LATEST" | sed 's|dsymprocessor/||')
+          else
+            LATEST="$CURRENT"
+          fi
+          echo "Latest dsymprocessor version: $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check symbolicator/proguardprocessor
+        id: symbolicator_proguard
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          CURRENT=$(grep 'symbolicator/proguardprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+          echo "Current proguardprocessor version: $CURRENT"
+
+          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("proguardprocessor/"))] | first' 2>/dev/null || echo "")
+          if [ -n "$LATEST" ]; then
+            LATEST=$(echo "$LATEST" | sed 's|proguardprocessor/||')
+          else
+            LATEST="$CURRENT"
+          fi
+          echo "Latest proguardprocessor version: $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  create-otel-pr:
+    name: Create OTel Collector Update PR
+    needs: check-otel-collector
+    if: needs.check-otel-collector.outputs.updated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update versions and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW_CORE_V0: ${{ needs.check-otel-collector.outputs.new_core_v0 }}
+          NEW_CORE_V1: ${{ needs.check-otel-collector.outputs.new_core_v1 }}
+          NEW_CONTRIB_V0: ${{ needs.check-otel-collector.outputs.new_contrib_v0 }}
+        run: |
+          # Get current versions
+          CURRENT_CORE_V0=$(grep -m1 'go.opentelemetry.io/collector/exporter/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
+          CURRENT_CORE_V1=$(grep -m1 'go.opentelemetry.io/collector/confmap/provider/' builder-config.yaml | grep -oP 'v1\.\d+\.\d+')
+          CURRENT_CONTRIB_V0=$(grep -m1 'opentelemetry-collector-contrib/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
+
+          echo "Core v0: $CURRENT_CORE_V0 -> $NEW_CORE_V0"
+          echo "Core v1: $CURRENT_CORE_V1 -> $NEW_CORE_V1"
+          echo "Contrib v0: $CURRENT_CONTRIB_V0 -> $NEW_CONTRIB_V0"
+
+          BRANCH="auto/bump-otel-collector-${NEW_CORE_V1}-${NEW_CORE_V0}"
+          TITLE="maint: bump collector libs to ${NEW_CORE_V1}/${NEW_CORE_V0}"
+
+          # Check if a PR already exists for this update
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH, skipping."
+            exit 0
+          fi
+
+          # Create branch and apply changes
+          git checkout -b "$BRANCH"
+
+          # Update core v0.x versions (go.opentelemetry.io/collector/... modules + builder)
+          # Use targeted replacements to avoid touching contrib or honeycomb lines
+          sed -i "/go\.opentelemetry\.io\/collector\//s|${CURRENT_CORE_V0}|${NEW_CORE_V0}|g" builder-config.yaml
+          sed -i "s|builder@${CURRENT_CORE_V0}|builder@${NEW_CORE_V0}|g" Makefile
+
+          # Update core v1.x versions (confmap providers)
+          sed -i "/go\.opentelemetry\.io\/collector\/confmap/s|${CURRENT_CORE_V1}|${NEW_CORE_V1}|g" builder-config.yaml
+
+          # Update contrib v0.x versions (opentelemetry-collector-contrib modules)
+          sed -i "/opentelemetry-collector-contrib\//s|${CURRENT_CONTRIB_V0}|${NEW_CONTRIB_V0}|g" builder-config.yaml
+
+          echo "Updated files:"
+          git diff
+
+          # Commit and push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add builder-config.yaml Makefile
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+
+          # Create the PR
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat <<EOF
+          ## Automated Dependency Update
+
+          Bumps OTel Collector libraries:
+          - Core modules: \`${NEW_CORE_V0}\`
+          - Confmap providers: \`${NEW_CORE_V1}\`
+          - Collector Contrib modules: \`${NEW_CONTRIB_V0}\`
+          - Builder: \`${NEW_CORE_V0}\`
+
+          ## How to verify
+
+          \`\`\`
+          make build
+          \`\`\`
+
+          ---
+          *This PR was created automatically by the dependency update workflow.*
+          EOF
+          )" \
+            --label "type: dependencies"
+
+  create-honeycomb-pr:
+    name: Create Honeycomb Dependency Update PR
+    needs: check-honeycomb-deps
+    if: |
+      needs.check-honeycomb-deps.outputs.s3_exporter_updated == 'true' ||
+      needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated == 'true' ||
+      needs.check-honeycomb-deps.outputs.symbolicator_dsym_updated == 'true' ||
+      needs.check-honeycomb-deps.outputs.symbolicator_proguard_updated == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update versions and create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          S3_UPDATED: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_updated }}
+          S3_VERSION: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_version }}
+          SOURCEMAP_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated }}
+          SOURCEMAP_VERSION: ${{ needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_version }}
+          DSYM_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_dsym_updated }}
+          DSYM_VERSION: ${{ needs.check-honeycomb-deps.outputs.symbolicator_dsym_version }}
+          PROGUARD_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_proguard_updated }}
+          PROGUARD_VERSION: ${{ needs.check-honeycomb-deps.outputs.symbolicator_proguard_version }}
+        run: |
+          BRANCH="auto/bump-honeycomb-deps"
+          TITLE="maint: bump Honeycomb dependencies"
+
+          # Check if a PR already exists
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for branch $BRANCH, skipping."
+            exit 0
+          fi
+
+          git checkout -b "$BRANCH"
+
+          UPDATES=""
+
+          if [ "$S3_UPDATED" == "true" ]; then
+            CURRENT=$(grep 'enhance-indexing-s3-exporter' builder-config.yaml | grep -oP 'v[\d.]+')
+            sed -i "s|enhance-indexing-s3-exporter/enhanceindexings3exporter ${CURRENT}|enhance-indexing-s3-exporter/enhanceindexings3exporter ${S3_VERSION}|g" builder-config.yaml
+            UPDATES="${UPDATES}- enhance-indexing-s3-exporter: \`${S3_VERSION}\`\n"
+          fi
+
+          if [ "$SOURCEMAP_UPDATED" == "true" ]; then
+            CURRENT=$(grep 'symbolicator/sourcemapprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+            sed -i "s|symbolicator/sourcemapprocessor ${CURRENT}|symbolicator/sourcemapprocessor ${SOURCEMAP_VERSION}|g" builder-config.yaml
+            UPDATES="${UPDATES}- sourcemapprocessor: \`${SOURCEMAP_VERSION}\`\n"
+          fi
+
+          if [ "$DSYM_UPDATED" == "true" ]; then
+            CURRENT=$(grep 'symbolicator/dsymprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+            sed -i "s|symbolicator/dsymprocessor ${CURRENT}|symbolicator/dsymprocessor ${DSYM_VERSION}|g" builder-config.yaml
+            UPDATES="${UPDATES}- dsymprocessor: \`${DSYM_VERSION}\`\n"
+          fi
+
+          if [ "$PROGUARD_UPDATED" == "true" ]; then
+            CURRENT=$(grep 'symbolicator/proguardprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
+            sed -i "s|symbolicator/proguardprocessor ${CURRENT}|symbolicator/proguardprocessor ${PROGUARD_VERSION}|g" builder-config.yaml
+            UPDATES="${UPDATES}- proguardprocessor: \`${PROGUARD_VERSION}\`\n"
+          fi
+
+          echo "Updated files:"
+          git diff
+
+          # Commit and push
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add builder-config.yaml
+          git commit -m "$TITLE"
+          git push origin "$BRANCH"
+
+          # Create the PR
+          gh pr create \
+            --title "$TITLE" \
+            --body "$(cat <<EOF
+          ## Automated Dependency Update
+
+          Updates Honeycomb dependencies:
+          $(echo -e "$UPDATES")
+
+          ## How to verify
+
+          \`\`\`
+          make build
+          \`\`\`
+
+          ---
+          *This PR was created automatically by the dependency update workflow.*
+          EOF
+          )" \
+            --label "type: dependencies"

--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Check for OTel Collector updates
         id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Get current versions from builder-config.yaml
           CURRENT_CORE_V0=$(grep -m1 'go.opentelemetry.io/collector/exporter/' builder-config.yaml | grep -oP 'v0\.\d+\.\d+')
@@ -35,20 +33,16 @@ jobs:
           echo "Current collector core v1: $CURRENT_CORE_V1"
           echo "Current collector contrib v0: $CURRENT_CONTRIB_V0"
 
-          # Check open-telemetry/opentelemetry-collector for core v0.x tags
-          LATEST_CORE_V0=$(gh api repos/open-telemetry/opentelemetry-collector/tags --per_page=100 \
-            --jq '[.[].name | select(test("^v0\\.\\d+\\.\\d+$"))] | first')
-          echo "Latest collector core v0 tag: $LATEST_CORE_V0"
+          # Query the Go module proxy for latest stable versions
+          # The /@latest endpoint returns only stable releases, skipping pre-release/beta/RC versions
+          LATEST_CORE_V0=$(curl -sf 'https://proxy.golang.org/go.opentelemetry.io/collector/exporter/debugexporter/@latest' | jq -r '.Version')
+          echo "Latest collector core v0 (from Go proxy): $LATEST_CORE_V0"
 
-          # Check open-telemetry/opentelemetry-collector for core v1.x tags (confmap providers)
-          LATEST_CORE_V1=$(gh api repos/open-telemetry/opentelemetry-collector/tags --per_page=100 \
-            --jq '[.[].name | select(test("^v1\\.\\d+\\.\\d+$"))] | first')
-          echo "Latest collector core v1 tag: $LATEST_CORE_V1"
+          LATEST_CORE_V1=$(curl -sf 'https://proxy.golang.org/go.opentelemetry.io/collector/confmap/provider/envprovider/@latest' | jq -r '.Version')
+          echo "Latest collector core v1 (from Go proxy): $LATEST_CORE_V1"
 
-          # Check open-telemetry/opentelemetry-collector-contrib for contrib v0.x tags
-          LATEST_CONTRIB_V0=$(gh api repos/open-telemetry/opentelemetry-collector-contrib/tags --per_page=100 \
-            --jq '[.[].name | select(test("^v0\\.\\d+\\.\\d+$"))] | first')
-          echo "Latest collector contrib v0 tag: $LATEST_CONTRIB_V0"
+          LATEST_CONTRIB_V0=$(curl -sf 'https://proxy.golang.org/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter/@latest' | jq -r '.Version')
+          echo "Latest collector contrib v0 (from Go proxy): $LATEST_CONTRIB_V0"
 
           CORE_V0_CHANGED="false"
           CORE_V1_CHANGED="false"
@@ -95,19 +89,14 @@ jobs:
 
       - name: Check enhance-indexing-s3-exporter
         id: s3_exporter
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT=$(grep 'enhance-indexing-s3-exporter' builder-config.yaml | grep -oP 'v[\d.]+')
           echo "Current s3-exporter version: $CURRENT"
 
-          LATEST=$(gh api repos/honeycombio/enhance-indexing-s3-exporter/releases/latest --jq '.tag_name' 2>/dev/null || echo "")
-          if [ -z "$LATEST" ]; then
-            LATEST=$(gh api repos/honeycombio/enhance-indexing-s3-exporter/tags --jq '.[0].name' 2>/dev/null || echo "$CURRENT")
-          fi
-          echo "Latest s3-exporter version: $LATEST"
+          LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter/@latest' | jq -r '.Version')
+          echo "Latest s3-exporter version (from Go proxy): $LATEST"
 
-          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ]; then
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           else
@@ -116,21 +105,14 @@ jobs:
 
       - name: Check symbolicator/sourcemapprocessor
         id: symbolicator_sourcemap
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT=$(grep 'symbolicator/sourcemapprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
           echo "Current sourcemapprocessor version: $CURRENT"
 
-          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("sourcemapprocessor/"))] | first' 2>/dev/null || echo "")
-          if [ -n "$LATEST" ]; then
-            LATEST=$(echo "$LATEST" | sed 's|sourcemapprocessor/||')
-          else
-            LATEST="$CURRENT"
-          fi
-          echo "Latest sourcemapprocessor version: $LATEST"
+          LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor/@latest' | jq -r '.Version')
+          echo "Latest sourcemapprocessor version (from Go proxy): $LATEST"
 
-          if [ "$LATEST" != "$CURRENT" ]; then
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           else
@@ -139,21 +121,14 @@ jobs:
 
       - name: Check symbolicator/dsymprocessor
         id: symbolicator_dsym
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT=$(grep 'symbolicator/dsymprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
           echo "Current dsymprocessor version: $CURRENT"
 
-          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("dsymprocessor/"))] | first' 2>/dev/null || echo "")
-          if [ -n "$LATEST" ]; then
-            LATEST=$(echo "$LATEST" | sed 's|dsymprocessor/||')
-          else
-            LATEST="$CURRENT"
-          fi
-          echo "Latest dsymprocessor version: $LATEST"
+          LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor/@latest' | jq -r '.Version')
+          echo "Latest dsymprocessor version (from Go proxy): $LATEST"
 
-          if [ "$LATEST" != "$CURRENT" ]; then
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           else
@@ -162,21 +137,14 @@ jobs:
 
       - name: Check symbolicator/proguardprocessor
         id: symbolicator_proguard
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CURRENT=$(grep 'symbolicator/proguardprocessor' builder-config.yaml | grep -oP 'v[\d.]+')
           echo "Current proguardprocessor version: $CURRENT"
 
-          LATEST=$(gh api repos/honeycombio/opentelemetry-collector-symbolicator/tags --jq '[.[].name | select(startswith("proguardprocessor/"))] | first' 2>/dev/null || echo "")
-          if [ -n "$LATEST" ]; then
-            LATEST=$(echo "$LATEST" | sed 's|proguardprocessor/||')
-          else
-            LATEST="$CURRENT"
-          fi
-          echo "Latest proguardprocessor version: $LATEST"
+          LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor/@latest' | jq -r '.Version')
+          echo "Latest proguardprocessor version (from Go proxy): $LATEST"
 
-          if [ "$LATEST" != "$CURRENT" ]; then
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
             echo "version=$LATEST" >> "$GITHUB_OUTPUT"
           else

--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -6,14 +6,12 @@ on:
     - cron: "0 14 * * *"
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   check-otel-collector:
     name: Check OTel Collector Updates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       updated: ${{ steps.check.outputs.updated }}
       new_core_v0: ${{ steps.check.outputs.new_core_v0 }}
@@ -61,18 +59,18 @@ jobs:
           CORE_V1_CHANGED="false"
           CONTRIB_V0_CHANGED="false"
 
-          if [ "$LATEST_CORE_V0" != "$CURRENT_CORE_V0" ]; then
+          if [ "$LATEST_CORE_V0" != "$CURRENT_CORE_V0" ] && [ -n "$LATEST_CORE_V0" ] && [ "$LATEST_CORE_V0" != "null" ]; then
             CORE_V0_CHANGED="true"
           fi
-          if [ "$LATEST_CORE_V1" != "$CURRENT_CORE_V1" ]; then
+          if [ "$LATEST_CORE_V1" != "$CURRENT_CORE_V1" ] && [ -n "$LATEST_CORE_V1" ] && [ "$LATEST_CORE_V1" != "null" ]; then
             CORE_V1_CHANGED="true"
           fi
-          if [ "$LATEST_CONTRIB_V0" != "$CURRENT_CONTRIB_V0" ]; then
+          if [ "$LATEST_CONTRIB_V0" != "$CURRENT_CONTRIB_V0" ] && [ -n "$LATEST_CONTRIB_V0" ] && [ "$LATEST_CONTRIB_V0" != "null" ]; then
             CONTRIB_V0_CHANGED="true"
           fi
 
           GO_CHANGED="false"
-          if [ "$UPSTREAM_GO" != "$CURRENT_GO_MINOR" ]; then
+          if [ "$UPSTREAM_GO" != "$CURRENT_GO_MINOR" ] && [ -n "$UPSTREAM_GO" ]; then
             GO_CHANGED="true"
           fi
 
@@ -101,6 +99,8 @@ jobs:
   check-honeycomb-deps:
     name: Check Honeycomb Dependency Updates
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       s3_exporter_updated: ${{ steps.s3_exporter.outputs.updated }}
       s3_exporter_version: ${{ steps.s3_exporter.outputs.version }}
@@ -182,6 +182,9 @@ jobs:
     needs: check-otel-collector
     if: needs.check-otel-collector.outputs.updated == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
 
@@ -244,7 +247,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add builder-config.yaml Makefile Dockerfile
           git commit -m "$TITLE"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
           # Create the PR
           gh pr create \
@@ -274,6 +277,9 @@ jobs:
   create-honeycomb-pr:
     name: Create Honeycomb Dependency Update PR
     needs: check-honeycomb-deps
+    permissions:
+      contents: write
+      pull-requests: write
     if: |
       needs.check-honeycomb-deps.outputs.s3_exporter_updated == 'true' ||
       needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated == 'true' ||
@@ -295,8 +301,24 @@ jobs:
           PROGUARD_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_proguard_updated }}
           PROGUARD_VERSION: ${{ needs.check-honeycomb-deps.outputs.symbolicator_proguard_version }}
         run: |
-          BRANCH="auto/bump-honeycomb-deps"
           TITLE="maint: bump Honeycomb dependencies"
+          UPDATES=""
+          BRANCH_SUFFIX=""
+
+          if [ "$S3_UPDATED" == "true" ]; then
+            BRANCH_SUFFIX="${BRANCH_SUFFIX}-s3-exporter-${S3_VERSION}"
+          fi
+          if [ "$SOURCEMAP_UPDATED" == "true" ]; then
+            BRANCH_SUFFIX="${BRANCH_SUFFIX}-sourcemap-${SOURCEMAP_VERSION}"
+          fi
+          if [ "$DSYM_UPDATED" == "true" ]; then
+            BRANCH_SUFFIX="${BRANCH_SUFFIX}-dsym-${DSYM_VERSION}"
+          fi
+          if [ "$PROGUARD_UPDATED" == "true" ]; then
+            BRANCH_SUFFIX="${BRANCH_SUFFIX}-proguard-${PROGUARD_VERSION}"
+          fi
+
+          BRANCH="auto/bump${BRANCH_SUFFIX}"
 
           # Check if a PR already exists
           EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number' 2>/dev/null || echo "")
@@ -306,8 +328,6 @@ jobs:
           fi
 
           git checkout -b "$BRANCH"
-
-          UPDATES=""
 
           if [ "$S3_UPDATED" == "true" ]; then
             CURRENT=$(grep 'enhance-indexing-s3-exporter' builder-config.yaml | grep -oP 'v[\d.]+')
@@ -341,7 +361,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add builder-config.yaml
           git commit -m "$TITLE"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
           # Create the PR
           gh pr create \


### PR DESCRIPTION
## Summary

Adds a daily cron GitHub Actions workflow that automatically detects new upstream dependency versions and creates PRs to bump them.

**Version detection uses the Go module proxy (`proxy.golang.org/@latest`)** to ensure we only bump to versions that are actually published and pullable — avoiding race conditions with tags or GitHub releases that haven't been fully published yet. The proxy also naturally filters out pre-release/beta/RC versions.

### What it checks

- **OTel Collector core** (`go.opentelemetry.io/collector/...`) — `v0.x` modules and `v1.x` confmap providers, checked independently
- **OTel Collector Contrib** (`github.com/open-telemetry/opentelemetry-collector-contrib/...`) — checked independently from core, not assumed to match
- **Go version** — reads the `go` directive from the upstream collector's `go.mod` and updates the `Dockerfile` `FROM golang:` image tag to match (major.minor only; `.tool-versions` is left for manual patch-level updates)
- **Honeycomb dependencies** — `enhance-indexing-s3-exporter` and the three `opentelemetry-collector-symbolicator` sub-modules (`sourcemapprocessor`, `dsymprocessor`, `proguardprocessor`)

### How it works

- OTel Collector + Go version changes are grouped into a single PR (since they release in lockstep)
- Honeycomb dependency changes are grouped into a separate PR (independent release cycles)
- Uses only `actions/checkout` + native `git`/`gh`/`curl` commands — no third-party actions
- Checks for existing open PRs on the target branch to avoid duplicates
- Supports manual triggering via `workflow_dispatch`

## Test plan

A lot of these are pretty hard to test until this is actually merged...  So testing is going to be seeing if this works whenever the next updates roll out, and then adjusting as needed. (Note by Davin - an Actual Human:tm:)

- [ ] Trigger workflow manually via `workflow_dispatch` to verify version detection logic
- [ ] Verify PR creation works correctly when updates are available
- [ ] Confirm targeted `sed` replacements only touch the intended lines (core vs contrib vs honeycomb)
- [ ] Validate that the workflow skips PR creation when versions are already up to date
- [ ] Verify Go version detection correctly parses the upstream collector's `go.mod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)