### PR TITLE
rel: prep v0.0.29 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.0.29 [beta] - 2026-04-20
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.56.0/v0.150.0 (#76) | @tdarwin
+
+### 🤖 CI
+
+- ci: add automated dependency update workflow (#75) | @tdarwin
+
 ## v0.0.28 [beta] - 2026-04-07
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.28
+  version: 0.0.29
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prep release of the distro at v0.0.29.

- Bumps `dist.version` in `builder-config.yaml` from `0.0.28` → `0.0.29`.
- Adds changelog entries for what landed since v0.0.28:
  - #76 — bump collector libs to v1.56.0/v0.150.0
  - #75 — add automated dependency update workflow

## Test plan

- [x] CI green
- [x] After merge, tag `v0.0.29` and publish the release