### PR TITLE
maint: bump enhance-indexing-s3-exporter to v0.0.15

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,7 +12,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.150.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.150.0
-  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.14
+  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.15
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.150.0


### PR DESCRIPTION
## Automated Dependency Update

Bumps the Honeycomb Enhance Indexing S3 Exporter:
- `github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter`: `v0.0.14` → `v0.0.15`

## How to verify

```
make build
```

---
*Opened manually from the branch produced by the dependency update workflow (the workflow could not open the PR itself until the repo setting "Allow GitHub Actions to create and approve pull requests" was enabled).*