### PR TITLE
maint: bump enhance-indexing-s3-exporter to v0.0.17

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,7 +12,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.150.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.150.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.150.0
-  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.15
+  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.17
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.150.0


### PR DESCRIPTION
## Summary
- Bumps `github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter` from v0.0.15 → v0.0.17 in `builder-config.yaml`.
- Generated by the automated dependency update workflow.

## Test plan
- [ ] CI build of the distro succeeds with the new exporter version.