### PR TITLE
ci: use GHA_PR_TOKEN PAT for dependency update PR creation

### DIFF
--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -190,7 +190,7 @@ jobs:
 
       - name: Update versions and create PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHA_PR_TOKEN }}
           NEW_CORE_V0: ${{ needs.check-otel-collector.outputs.new_core_v0 }}
           NEW_CORE_V1: ${{ needs.check-otel-collector.outputs.new_core_v1 }}
           NEW_CONTRIB_V0: ${{ needs.check-otel-collector.outputs.new_contrib_v0 }}
@@ -291,7 +291,7 @@ jobs:
 
       - name: Update versions and create PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHA_PR_TOKEN }}
           S3_UPDATED: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_updated }}
           S3_VERSION: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_version }}
           SOURCEMAP_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated }}


### PR DESCRIPTION
## Summary
- Switches `GH_TOKEN` in the `create-otel-pr` and `create-honeycomb-pr` steps from `secrets.GITHUB_TOKEN` to `secrets.GHA_PR_TOKEN` (a PAT with PR-create permissions).
- Read-only check steps continue to use `GITHUB_TOKEN`.

## Why
PRs created with the default `GITHUB_TOKEN` do not trigger downstream workflows (CI checks, label automation, etc.). Using a PAT for the `gh pr create` calls means our auto-generated dependency PRs will run CI on open, so they're ready to review without a manual nudge.

## Test plan
- [x] After merge, manually dispatch the `Check Dependency Updates` workflow and confirm any opened PR runs CI.