### PR TITLE
maint: update CODEOWNERS to field-reliability-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/field-engineering @honeycombio/oss-maintainers @honeycombio/agentic-observability
+* @honeycombio/field-reliability-engineering @honeycombio/oss-maintainers @honeycombio/agentic-observability


### PR DESCRIPTION
## Summary
- Replaces `@honeycombio/field-engineering` with `@honeycombio/field-reliability-engineering` as the default reviewer team in `.github/CODEOWNERS`.

## Test plan
- [ ] After merge, confirm new PRs auto-request review from `@honeycombio/field-reliability-engineering`.