### PR TITLE
rel: prep v0.0.30 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v0.0.30 [beta] - 2026-05-07
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.57.0/v0.151.0 (#80) | @tdarwin
+- maint: bump enhance-indexing-s3-exporter to v0.0.17 (#79) | @tdarwin
+- maint: bump enhance-indexing-s3-exporter to v0.0.15 (#78) | @tdarwin
+- maint: update CODEOWNERS to field-reliability-engineering (#82) | @tdarwin
+
+### 🤖 CI
+
+- ci: use GHA_PR_TOKEN PAT for dependency update PR creation (#81) | @tdarwin
+
 ## v0.0.29 [beta] - 2026-04-20
 
 ### 🛠️ Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - maint: bump collector libs to v1.57.0/v0.151.0 (#80) | @tdarwin
 - maint: bump enhance-indexing-s3-exporter to v0.0.17 (#79) | @tdarwin
-- maint: bump enhance-indexing-s3-exporter to v0.0.15 (#78) | @tdarwin
 - maint: update CODEOWNERS to field-reliability-engineering (#82) | @tdarwin
 
 ## v0.0.29 [beta] - 2026-04-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@
 - maint: bump enhance-indexing-s3-exporter to v0.0.15 (#78) | @tdarwin
 - maint: update CODEOWNERS to field-reliability-engineering (#82) | @tdarwin
 
-### 🤖 CI
-
-- ci: use GHA_PR_TOKEN PAT for dependency update PR creation (#81) | @tdarwin
-
 ## v0.0.29 [beta] - 2026-04-20
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.29
+  version: 0.0.30
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prep release of the distro at v0.0.30.

- Bumps `dist.version` in `builder-config.yaml` from `0.0.29` → `0.0.30`.
- Adds changelog entries for what landed since v0.0.29:
  - #80 — bump collector libs to v1.57.0/v0.151.0
  - #79 — bump enhance-indexing-s3-exporter to v0.0.17
  - #82 — update CODEOWNERS to field-reliability-engineering

## Test plan

- [x] CI green
- [ ] After merge, tag `v0.0.30` and publish the release