### PR TITLE
rel: prep v0.0.31 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## v0.0.31 [beta] - 2026-05-12
+
+### ✨ Features
+
+- feat: add drain processor (#85) | @tdarwin
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.58.0/v0.152.0 (#84) | @tdarwin
+
 ## v0.0.30 [beta] - 2026-05-07
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.30
+  version: 0.0.31
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.31 release including:

- feat: add drain processor (#85)
- maint: bump collector libs to v1.58.0/v0.152.0 (#84)
