### PR TITLE
rel: prep v0.0.32 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.0.32 [beta] - 2026-05-27
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.59.0/v0.153.0 (#88) | @tdarwin
+- maint: bump Honeycomb dependencies (#89) | @tdarwin
+
 ## v0.0.31 [beta] - 2026-05-12
 
 ### ✨ Features

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.31
+  version: 0.0.32
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.32 release including:

- maint: bump collector libs to v1.59.0/v0.153.0 (#88)
- maint: bump Honeycomb dependencies (#89)

## Test plan

- [x] CI green
- [x] `make build-docker` builds multi-arch image (already verified locally on #88)