### PR TITLE
maint: bump collector libs to v1.60.0/v0.154.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: builder
 builder:
-	go install go.opentelemetry.io/collector/cmd/builder@v0.153.0
+	go install go.opentelemetry.io/collector/cmd/builder@v0.154.0
 
 .PHONY: clean
 clean:

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -7,16 +7,16 @@ dist:
   cgo_enabled: true
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.153.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.153.0
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.153.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.153.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.154.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.154.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.154.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.153.0
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.19
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.153.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.153.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.154.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.153.0
@@ -28,8 +28,8 @@ processors:
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v1.0.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.153.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.153.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.154.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.153.0
@@ -44,15 +44,15 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.153.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.59.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.59.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.59.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.59.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.59.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.60.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.60.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.60.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.60.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.60.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.153.0
 
 extensions:
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.153.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.154.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.153.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.153.0


### PR DESCRIPTION
## Automated Dependency Update

Bumps OTel Collector libraries:
- Core modules: `v0.154.0`
- Confmap providers: `v1.60.0`
- Collector Contrib modules: `v0.153.0`
- Builder: `v0.154.0`


## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*