### PR TITLE
rel: prep v0.0.33 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.0.33 [beta] - 2026-06-09
+
+### 🛠️ Maintenance
+
+- maint: bump Honeycomb dependencies (#91) | @tdarwin
+- maint: bump collector libs to v1.60.0/v0.154.0 (#92) | @tdarwin
+
 ## v0.0.32 [beta] - 2026-05-27
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.32
+  version: 0.0.33
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.33 release including:

- maint: bump Honeycomb dependencies (#91)
- maint: bump collector libs to v1.60.0/v0.154.0 (#92)

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)