### PR TITLE
chore(codeowners): update Agent O11y and LLM O11y teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/field-reliability-engineering @honeycombio/oss-maintainers @honeycombio/agentic-observability
+* @honeycombio/field-reliability-engineering @honeycombio/oss-maintainers @honeycombio/llm-observability @honeycombio/ai-observability


### PR DESCRIPTION
Updating the codeowners to match teams.