### PR TITLE
maint: bump Honeycomb dependencies

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,7 +12,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.155.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.155.0
-  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.20
+  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.21
 
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.155.0


### PR DESCRIPTION
## Automated Dependency Update

Updates Honeycomb dependencies:
- enhance-indexing-s3-exporter: `v0.0.21`

## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*