### PR TITLE
feat: Request to add components

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,7 +12,6 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.155.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.155.0
-  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.155.0
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.20
 
 processors:

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,6 +12,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.155.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.155.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awss3exporter v0.155.0
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.20
 
 processors:
@@ -21,7 +22,9 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor v0.155.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.155.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.155.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v1.0.3
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v1.0.2
@@ -52,6 +55,7 @@ providers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.155.0
 
 extensions:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.155.0
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.155.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.155.0


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?
SumUp is evaluating the `honeycomb-collector-distro` image for our public-facing OpenTelemetry collector which ingests browser/mobile telemetry over OTLP/HTTP from the public internet and forwards traces/logs/metrics to our internal pipeline before Honeycomb

The distro already includes `sourcemapprocessor`, which we need for JS stack trace symbolication. However, our existing collector config (currently based on `opentelemetry-collector-contrib` 0.155.x) depends on three additional contrib components that are not present in `builder-config.yaml`:

1. **`basicauthextension`** — authenticates public OTLP/HTTP clients
2. **`redactionprocessor`** — allowlist-based trace attribute filtering
3. **`resourceprocessor`** — injects resource attributes to log records

Without these components, our public collector configuration fails validation against the distro binary.

## Short description of the changes
Add the following modules to `builder-config.yaml` (aligned with existing OTel `v0.155.0`):
**Extensions**
- `basicauthextension`
**Processors**
- `redactionprocessor`
- `resourceprocessor`
No changes to default runtime config or pipelines — this PR only expands the available component set in the distro build.

## How to verify that this has the expected result
1. Build the collector
2. Validate a minimal config that exercises all newly added components

```
cat > /tmp/public-collector-test.yaml <<'EOF'
extensions:
  basicauth:
    htpasswd:
      inline: |
        testuser:testpass
  health_check:

receivers:
  otlp:
    protocols:
      http:
        auth:
          authenticator: basicauth
        endpoint: 0.0.0.0:4318

processors:
  resource/log-labels:
    attributes:
      - action: insert
        key: deployment.environment
        value: test
  redaction/traces:
    allow_all_keys: false
    allowed_keys:
      - service.name
      - exception.stacktrace
  batch:

exporters:
  debug:

service:
  extensions: [basicauth, health_check]
  pipelines:
    traces:
      receivers: [otlp]
      processors: [redaction/traces, batch]
      exporters: [debug]
    logs:
      receivers: [otlp]
      processors: [resource/log-labels, batch]
      exporters: [debug]
EOF

./bin/honeycomb-otelcol validate --config /tmp/public-collector-test.yaml
```

Notes
We intentionally did not change existing Honeycomb defaults, this only adds components required