### PR TITLE
rel: prep v0.0.35 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.0.35 [beta] - 2026-07-07
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.62.0/v0.156.0 (#101) | @tdarwin
+
 ## v0.0.34 [beta] - 2026-07-02
 
 ### ✨ Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Unreleased
 
-## v0.0.35 [beta] - 2026-07-07
+## v0.0.35 [beta] - 2026-07-08
 
 ### 🛠️ Maintenance
 
 - maint: bump collector libs to v1.62.0/v0.156.0 (#101) | @tdarwin
+- maint: bump sourcemapprocessor to v1.0.4 (#103) | @robbkidd
 
 ## v0.0.34 [beta] - 2026-07-02
 

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.34
+  version: 0.0.35
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.35 release. Changes merged to `main` since v0.0.34:

### 🛠️ Maintenance

- maint: bump collector libs to v1.62.0/v0.156.0 (#101) | @tdarwin
- maint: bump sourcemapprocessor to v1.0.4 (#103) | @robbkidd

This PR bumps the distro version to `0.0.35` in `builder-config.yaml` and updates `CHANGELOG.md`. The gomod versions were already updated by #101 (core/contrib `v0.156.0`, confmap providers `v1.62.0`, builder `v0.156.0`) and #103 (`sourcemapprocessor v1.0.4`), which are merged into this branch via `main`.

## Test plan

- [x] `make build-docker` succeeds locally (linux/amd64 + linux/arm64)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)