### PR TITLE
maint: bump sourcemapprocessor to v1.0.4

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -25,7 +25,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.156.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.156.0
-  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v1.0.3
+  - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v1.0.4
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v1.0.2
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v1.0.1
 


### PR DESCRIPTION
## Which problem is this PR solving?

- Bring in [a fix](https://github.com/honeycombio/opentelemetry-collector-symbolicator/pull/149) for a bug in sourcemapprocessor finding the correct source map file to use for mapping source.

## Short description of the changes

- Bump sourcemapprocessor to v1.0.4

## How to verify that this has the expected result

It's kind of convoluted. I confirmed that a build of the collector from this branch correctly looked up source maps from a web app throwing stacktraces and made them human readable as intended.