### PR TITLE
rel: prep v0.0.36 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## v0.0.36 [beta] - 2026-07-21
+
+### 🛠️ Maintenance
+
+- maint: bump Honeycomb dependencies (#104) | @tdarwin
+- maint: bump collector libs to v1.63.0/v0.157.0 (#105) | @tdarwin
+
 ## v0.0.35 [beta] - 2026-07-08
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.35
+  version: 0.0.36
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.36 release. Changes merged to `main` since v0.0.35:

### 🛠️ Maintenance

- maint: bump Honeycomb dependencies (#104) | @tdarwin
- maint: bump collector libs to v1.63.0/v0.157.0 (#105) | @tdarwin

This PR bumps the distro version to `0.0.36` in `builder-config.yaml` and updates `CHANGELOG.md`. The gomod versions were already updated by #104 and #105, which are merged into this branch via `main`.

## Test plan

- [x] `make build-docker` succeeds locally (linux/amd64 + linux/arm64)
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)