### PR TITLE
feat: add honeycomb_auth extension

### DIFF
--- a/.github/workflows/check-dependency-updates.yml
+++ b/.github/workflows/check-dependency-updates.yml
@@ -104,6 +104,8 @@ jobs:
     outputs:
       s3_exporter_updated: ${{ steps.s3_exporter.outputs.updated }}
       s3_exporter_version: ${{ steps.s3_exporter.outputs.version }}
+      auth_extension_updated: ${{ steps.auth_extension.outputs.updated }}
+      auth_extension_version: ${{ steps.auth_extension.outputs.version }}
       symbolicator_sourcemap_updated: ${{ steps.symbolicator_sourcemap.outputs.updated }}
       symbolicator_sourcemap_version: ${{ steps.symbolicator_sourcemap.outputs.version }}
       symbolicator_dsym_updated: ${{ steps.symbolicator_dsym.outputs.updated }}
@@ -121,6 +123,22 @@ jobs:
 
           LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter/@latest' | jq -r '.Version')
           echo "Latest s3-exporter version (from Go proxy): $LATEST"
+
+          if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+            echo "version=$LATEST" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check honeycomb-auth-extension
+        id: auth_extension
+        run: |
+          CURRENT=$(grep 'honeycomb-auth-extension' builder-config.yaml | grep -oP 'v[\d.]+')
+          echo "Current honeycombauthextension version: $CURRENT"
+
+          LATEST=$(curl -sf 'https://proxy.golang.org/github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension/@latest' | jq -r '.Version')
+          echo "Latest honeycombauthextension version (from Go proxy): $LATEST"
 
           if [ "$LATEST" != "$CURRENT" ] && [ -n "$LATEST" ] && [ "$LATEST" != "null" ]; then
             echo "updated=true" >> "$GITHUB_OUTPUT"
@@ -282,6 +300,7 @@ jobs:
       pull-requests: write
     if: |
       needs.check-honeycomb-deps.outputs.s3_exporter_updated == 'true' ||
+      needs.check-honeycomb-deps.outputs.auth_extension_updated == 'true' ||
       needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated == 'true' ||
       needs.check-honeycomb-deps.outputs.symbolicator_dsym_updated == 'true' ||
       needs.check-honeycomb-deps.outputs.symbolicator_proguard_updated == 'true'
@@ -294,6 +313,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GHA_PR_TOKEN }}
           S3_UPDATED: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_updated }}
           S3_VERSION: ${{ needs.check-honeycomb-deps.outputs.s3_exporter_version }}
+          AUTH_EXT_UPDATED: ${{ needs.check-honeycomb-deps.outputs.auth_extension_updated }}
+          AUTH_EXT_VERSION: ${{ needs.check-honeycomb-deps.outputs.auth_extension_version }}
           SOURCEMAP_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_updated }}
           SOURCEMAP_VERSION: ${{ needs.check-honeycomb-deps.outputs.symbolicator_sourcemap_version }}
           DSYM_UPDATED: ${{ needs.check-honeycomb-deps.outputs.symbolicator_dsym_updated }}
@@ -307,6 +328,9 @@ jobs:
 
           if [ "$S3_UPDATED" == "true" ]; then
             BRANCH_SUFFIX="${BRANCH_SUFFIX}-s3-exporter-${S3_VERSION}"
+          fi
+          if [ "$AUTH_EXT_UPDATED" == "true" ]; then
+            BRANCH_SUFFIX="${BRANCH_SUFFIX}-auth-extension-${AUTH_EXT_VERSION}"
           fi
           if [ "$SOURCEMAP_UPDATED" == "true" ]; then
             BRANCH_SUFFIX="${BRANCH_SUFFIX}-sourcemap-${SOURCEMAP_VERSION}"
@@ -333,6 +357,12 @@ jobs:
             CURRENT=$(grep 'enhance-indexing-s3-exporter' builder-config.yaml | grep -oP 'v[\d.]+')
             sed -i "s|enhance-indexing-s3-exporter/enhanceindexings3exporter ${CURRENT}|enhance-indexing-s3-exporter/enhanceindexings3exporter ${S3_VERSION}|g" builder-config.yaml
             UPDATES="${UPDATES}- enhance-indexing-s3-exporter: \`${S3_VERSION}\`\n"
+          fi
+
+          if [ "$AUTH_EXT_UPDATED" == "true" ]; then
+            CURRENT=$(grep 'honeycomb-auth-extension' builder-config.yaml | grep -oP 'v[\d.]+')
+            sed -i "s|honeycomb-auth-extension/honeycombauthextension ${CURRENT}|honeycomb-auth-extension/honeycombauthextension ${AUTH_EXT_VERSION}|g" builder-config.yaml
+            UPDATES="${UPDATES}- honeycombauthextension: \`${AUTH_EXT_VERSION}\`\n"
           fi
 
           if [ "$SOURCEMAP_UPDATED" == "true" ]; then

--- a/README.md
+++ b/README.md
@@ -64,3 +64,4 @@ docker run \
 | Extension      | headerssetterextension | [headerssetterextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension) |
 | Extension      | healthcheckextension | [healthcheckextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension) |
 | Extension      | pprofextension | [pprofextension](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension) |
+| Extension      | honeycombauthextension | [honeycombauthextension](https://pkg.go.dev/github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension) |

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -60,3 +60,4 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.157.0
+  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.1.0


### PR DESCRIPTION
## Which problem is this PR solving?

Adds the [honeycomb_auth](https://github.com/honeycombio/honeycomb-auth-extension) server-authenticator extension to the distro so hosted/customer collectors can validate inbound Honeycomb ingest keys at the edge.

The extension validates the incoming x-honeycomb-team key against Honeycomb's /1/auth endpoint (cached, with stale fallback during auth-backend outages), can restrict accepted keys to specific team slugs via allowed_teams, and emits a per-outcome self-telemetry counter for abuse monitoring.

## Short description of the changes

- Add github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.1.0 under extensions in builder-config.yaml
- Add the extension to the component table in the README

## How to verify that this has the expected result

- CI builds the distro with the new component
- `make build`, then run with a config that sets `extensions: honeycomb_auth:` and `auth: authenticator: honeycomb_auth` on an OTLP receiver; requests with a valid ingest key for an allowed team pass, others are rejected with 401. See the [extension README](https://github.com/honeycombio/honeycomb-auth-extension/blob/main/README.md) for full configuration.