### PR TITLE
maint: bump honeycombauthextension to v0.2.0

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -60,4 +60,4 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.157.0
-  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.1.0
+  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.2.0


### PR DESCRIPTION
## Which problem is this PR solving?

Picks up [honeycombauthextension v0.2.0](https://github.com/honeycombio/honeycomb-auth-extension/releases/tag/honeycombauthextension%2Fv0.2.0), which adds environment-level restrictions requested for the hosted collector fleet:

- `allowed_environments`: restrict accepted keys to specific environment slugs (E&S keys)
- `allow_classic` (default true): gate Honeycomb Classic keys, which carry no environment
- New metric outcomes `environment_not_allowed` and `classic_not_allowed`

## Short description of the changes

- Bump `honeycomb-auth-extension/honeycombauthextension` from v0.1.0 to v0.2.0 in builder-config.yaml

## How to verify that this has the expected result

- `make build`; `./bin/honeycomb-otelcol components` lists honeycomb_auth at v0.2.0 (verified locally in a linux container with cgo)