### PR TITLE
maint: bump Honeycomb dependencies

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -60,4 +60,4 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.157.0
-  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.2.0
+  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.2.1


### PR DESCRIPTION
## Automated Dependency Update

Updates Honeycomb dependencies:
- honeycombauthextension: `v0.2.1`

## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*