### PR TITLE
feat: request add routing connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ docker run \
 | Exporter       | otlphttpexporter | [otlphttpexporter](https://pkg.go.dev/go.opentelemetry.io/collector/exporter/otlphttpexporter) |
 | Exporter       | fileexporter   | [fileexporter](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter) |
 | Exporter       | enhanceindexings3exporter | [enhanceindexings3exporter](https://pkg.go.dev/github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter) |
+| Connector      | routingconnector | [routingconnector](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector) |
 | Processor      | batchprocessor | [batchprocessor](https://pkg.go.dev/go.opentelemetry.io/collector/processor/batchprocessor) |
 | Processor      | memorylimiterprocessor | [memorylimiterprocessor](https://pkg.go.dev/go.opentelemetry.io/collector/processor/memorylimiterprocessor) |
 | Processor      | filterprocessor | [filterprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor) |

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -14,6 +14,9 @@ exporters:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.157.0
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.23
 
+connectors:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.157.0
+
 processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
   - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.157.0


### PR DESCRIPTION
<!--
Thank you for contributing to the project! 💜
Please see our [OSS process document](https://github.com/honeycombio/home/blob/main/honeycomb-oss-lifecycle-and-practices.md#) to get an idea of how we operate.
-->

## Which problem is this PR solving?

It enables routing of different signal types to different processor pipelines. For example, using the same application for frontend open-telemetry, we'd want to route differently signals from web/browser compared to the mobile app.

## Short description of the changes

It adds the [routingprocessor connector](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor) in the `builder-config.yaml` that enables this routing.

## How to verify that this has the expected result

With a config like, where if the condition is true, the trace will be routed to traces/mobile
```
connectors:
  routing/traces:
    default_pipelines:
      - traces
    table:
      - condition: resource.attributes["my.attribute"] == "my-attribute-value"
         context: span
         pipelines:
           - traces/mobile
...
```