### PR TITLE
rel: prep v0.0.37 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## v0.0.37 [beta] - 2026-08-04
+
+### ✨ Features
+
+- feat: add honeycomb_auth extension (#107) | @MikeGoldsmith
+- feat: request add routing connector (#111) | @stratospal
+
+### 🛠️ Maintenance
+
+- maint: bump honeycombauthextension to v0.2.0 (#109) | @MikeGoldsmith
+- maint: bump Honeycomb dependencies (#108) | @tdarwin
+- maint: bump Honeycomb dependencies (#110) | @tdarwin
+
 ## v0.0.36 [beta] - 2026-07-21
 
 ### 🛠️ Maintenance

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.36
+  version: 0.0.37
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
## Summary

Prepare v0.0.37 release. Changes merged to `main` since v0.0.36:

### ✨ Features

- feat: add honeycomb_auth extension (#107) | @MikeGoldsmith
- feat: request add routing connector (#111) | @stratospal

### 🛠️ Maintenance

- maint: bump honeycombauthextension to v0.2.0 (#109) | @MikeGoldsmith
- maint: bump Honeycomb dependencies (#108) | @tdarwin
- maint: bump Honeycomb dependencies (#110) | @tdarwin

This PR bumps the distro version to `0.0.37` in `builder-config.yaml` and updates `CHANGELOG.md`.

## Test plan

- [x] `make build-docker` succeeds locally (linux/amd64 + linux/arm64)
- [ ] CI green