### PR TITLE
maint: bump collector libs to v1.64.0/v0.158.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: builder
 builder:
-	go install go.opentelemetry.io/collector/cmd/builder@v0.157.0
+	go install go.opentelemetry.io/collector/cmd/builder@v0.158.0
 
 .PHONY: clean
 clean:

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -7,10 +7,10 @@ dist:
   cgo_enabled: true
 
 exporters:
-  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.157.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.157.0
-  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.157.0
-  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.157.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.158.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.158.0
+  - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.158.0
+  - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.157.0
   - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.23
 
@@ -18,8 +18,8 @@ connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.157.0
 
 processors:
-  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.157.0
-  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.157.0
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.158.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/attributesprocessor v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricstransformprocessor v0.157.0
@@ -33,8 +33,8 @@ processors:
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v1.0.1
 
 receivers:
-  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.157.0
-  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.157.0
+  - gomod: go.opentelemetry.io/collector/receiver/nopreceiver v0.158.0
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filelogreceiver v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.157.0
@@ -49,16 +49,16 @@ receivers:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.157.0
 
 providers:
-  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.63.0
-  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.63.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.64.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/yamlprovider v1.64.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.157.0
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.157.0
-  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.157.0
+  - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/bearertokenauthextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.157.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.157.0


### PR DESCRIPTION
## Automated Dependency Update

Bumps OTel Collector libraries:
- Core modules: `v0.158.0`
- Confmap providers: `v1.64.0`
- Collector Contrib modules: `v0.157.0`
- Builder: `v0.158.0`


## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*