### PR TITLE
feat: add dynamic_sampling processor [OTEL-453]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ docker run \
 | Processor      | resourcedetectionprocessor | [resourcedetectionprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor) |
 | Processor      | resourceprocessor | [resourceprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor) |
 | Processor      | drainprocessor | [drainprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor) |
+| Processor      | dynamicsamplingprocessor | [dynamicsamplingprocessor](https://pkg.go.dev/github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor) |
 | Processor      | sourcemapprocessor | [sourcemapprocessor](https://pkg.go.dev/github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor) |
 | Processor      | dsymprocessor | [dsymprocessor](https://pkg.go.dev/github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor) |
 | Processor      | proguardprocessor | [proguardprocessor](https://pkg.go.dev/github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor) |

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -28,6 +28,7 @@ processors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourceprocessor v0.158.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/drainprocessor v0.158.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/processor/dynamicsamplingprocessor v0.158.0
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/sourcemapprocessor v1.0.4
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/dsymprocessor v1.0.2
   - gomod: github.com/honeycombio/opentelemetry-collector-symbolicator/proguardprocessor v1.0.1


### PR DESCRIPTION
## Which problem is this PR solving?

- [OTEL-453](https://linear.app/honeycombio/issue/OTEL-453/add-sampler-to-honeycomb-distro)

## Short description of the changes

Adds the `dynamic_sampling` processor from collector-contrib to the distro, pinned at v0.158.0 to match the other contrib components. I maintain the processor upstream. It's still development stability (the alpha promotion is in flight), but having it in the distro lets us test it in real pipelines and gather feedback on the config shape while it's still cheap to change. The distro already ships early-stability components (`drain`), so there's precedent.

The automated dependency bumps will pick up newer versions as they release, v0.159.0 will bring the shutdown drain and metric label fixes.

## How to verify that this has the expected result

1. `make build` then `./bin/honeycomb-otelcol components` lists `dynamic_sampling` under processors.
2. A pipeline config with a `dynamic_sampling` block (rules + `ema_dynamic` sampler) passes `validate` and samples traces with `ot=th` on kept spans. The [processor README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/dynamicsamplingprocessor) has worked examples.

Verified locally with OCB source generation (module resolution + component registration); my machine currently can't link cgo binaries so CI does the compile check.
