### PR TITLE
rel: prep v0.0.38 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+## v0.0.38 [beta] - 2026-08-17
+
+### ✨ Features
+
+- feat: add dynamic_sampling processor [OTEL-453] (#117) | @MikeGoldsmith
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.64.0/v0.158.0 (#113, #114) | @tdarwin
+- maint: bump Honeycomb dependencies (#115, #116) | @tdarwin
+
 ## v0.0.37 [beta] - 2026-08-04
 
 ### ✨ Features

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.37
+  version: 0.0.38
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
Release prep for v0.0.38.

## Changes since v0.0.37

### ✨ Features
- add `dynamic_sampling` processor (#117) [OTEL-453]

### 🛠️ Maintenance
- bump collector libs to v1.64.0/v0.158.0 (#113, #114)
- bump Honeycomb dependencies (#115, #116)

Updates `CHANGELOG.md` and the distro `version` in `builder-config.yaml` to `0.0.38`.

After merge: tag `v0.0.38` on the merged commit and push it to kick off the release pipeline, then publish the generated GitHub draft release to trigger the Dockerhub publish (per `RELEASING.md`).