### PR TITLE
rel: prep v0.0.39 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.0.39 [beta] - 2026-08-18
+
+### 🛠️ Maintenance
+
+- maint: bump collector libs to v1.65.0/v0.159.0 (#120) | @tdarwin
+
 ## v0.0.38 [beta] - 2026-08-17
 
 ### ✨ Features

--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   description: Honeycomb OpenTelemetry Collector distribution
   output_path: ./bin
   # version of the distro
-  version: 0.0.38
+  version: 0.0.39
   cgo_enabled: true
 
 exporters:


### PR DESCRIPTION
**Linear:** none

## Summary

Release prep for v0.0.39, cutting a release for the OpenTelemetry Collector library bump to v1.65.0/v0.159.0 (#120) that landed after v0.0.38 went out yesterday. Adds the v0.0.39 changelog entry and bumps the distro `version` in `builder-config.yaml`.

Reviewers should confirm the version bump and changelog entry match. Note that #119 (CI builder-config validation) is intentionally omitted from the changelog — CI-only changes aren't included.

## How to Test

1. Confirm `builder-config.yaml` has `version: 0.0.39` under the `dist` key.
2. Confirm the `CHANGELOG.md` entry for v0.0.39 lists the collector libs bump (#120) and nothing else.
3. Let CI validate the builder config and build.

After merge, per `RELEASING.md`: tag `v0.0.39` on the merged commit and push it to kick off the CircleCI release pipeline, then publish the GitHub release.