### PR TITLE
chore: update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
 # For anything not explicitly taken by someone else:
-* @honeycombio/field-reliability-engineering @honeycombio/oss-maintainers @honeycombio/llm-observability @honeycombio/ai-observability
+* @honeycombio/field-reliability-engineering @honeycombio/oss-maintainers


### PR DESCRIPTION
Remove `llm-observability` and `ai-observability` teams from CODEOWNERS.
