### PR TITLE
maint: bump go to 1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /go/src
 


### PR DESCRIPTION
## Automated Dependency Update

Bumps OTel Collector libraries:
- Core modules: `v0.159.0`
- Confmap providers: `v1.65.0`
- Collector Contrib modules: `v0.159.0`
- Builder: `v0.159.0`
- Go version (Dockerfile): `1.25` → `1.26`

## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*