### PR TITLE
maint: bump Honeycomb dependencies

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -12,7 +12,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.159.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.159.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.159.0
-  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.25
+  - gomod: github.com/honeycombio/enhance-indexing-s3-exporter/enhanceindexings3exporter v0.0.26
 
 connectors:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector v0.159.0
@@ -64,4 +64,4 @@ extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension v0.159.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension v0.159.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.159.0
-  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.2.1
+  - gomod: github.com/honeycombio/honeycomb-auth-extension/honeycombauthextension v0.3.0


### PR DESCRIPTION
## Automated Dependency Update

Updates Honeycomb dependencies:
- enhance-indexing-s3-exporter: `v0.0.26`
- honeycombauthextension: `v0.3.0`

## How to verify

```
make build
```

---
*This PR was created automatically by the dependency update workflow.*